### PR TITLE
Pester config

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ end
 
 ```ruby
 # To set Pester to retry on ALL exception classes, do this (use with caution - this can include exceptions Rails likes to throw on SIGHUP)
-```ruby
 Pester.configure do |config|
   config.environments[:survey_gizmo_ruby][:retry_error_classes] = nil
 end

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Pester.configure do |config|
   config.environments[:survey_gizmo_ruby][:max_attempts] = 10
   # Backoff for 2 minutes
   config.environments[:survey_gizmo_ruby][:delay_interval] = 120
-  # Retry another exception class
-  config.environments[:survey_gizmo_ruby][:retry_error_classes] += [MyExceptionClass]
+  # Retry different exception classes
+  config.environments[:survey_gizmo_ruby][:retry_error_classes] = [MyExceptionClass, MyOtherExceptionClass]
 end
 
 # To set Pester to retry on ALL exception classes, do this (use with caution - this can include exceptions Rails likes to throw on SIGHUP)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ SurveyGizmo.configure do |config|
 end
 ```
 
+### Retries
+
 [Pester](https://github.com/lumoslabs/pester) will be configured to handle 1 retry with a 60 second timeout upon encountering basic net timeouts and rate limit errors.  If you want to specify more retries, a longer backoff, new classes to retry on, or otherwise get fancy with the retry strategy, you can configured Pester directly.  SurveyGizmo API calls are executed in Pester's `survey_gizmo_ruby` environment, so anything you configure there will apply to all your requests. **Just take care that you add additional `Pester` configuration AFTER you configure this gem** (configuring this gem will reset the `:survey_gizmo_ruby` Pester environment).
 
 For example, to change the retry interval, max attempts, or exception classes to be retried:

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Pester.configure do |config|
 end
 ```
 
+To set Pester to retry on ALL exception classes, do this (use with caution - this can include exceptions Rails likes to throw on SIGHUP)
 ```ruby
-# To set Pester to retry on ALL exception classes, do this (use with caution - this can include exceptions Rails likes to throw on SIGHUP)
 Pester.configure do |config|
   config.environments[:survey_gizmo_ruby][:retry_error_classes] = nil
 end

--- a/README.md
+++ b/README.md
@@ -65,10 +65,8 @@ The [Pester](https://github.com/lumoslabs/pester) gem is used to manage retry st
 
 If, however, you want to specify more retries, a longer backoff, new classes to retry on, or otherwise get fancy with the retry strategy, you can configured Pester directly.  SurveyGizmo API calls are executed in Pester's `survey_gizmo_ruby` environment, so anything you configure there will apply to all your requests.
 
-**Just take care that you add additional `Pester` configuration AFTER you configure this gem** (configuring this gem will reset the `:survey_gizmo_ruby` Pester environment).
-
-For example, to change the retry interval, max attempts, or exception classes to be retried:
 ```ruby
+# For example, to change the retry interval, max attempts, or exception classes to be retried:
 Pester.configure do |config|
   # Retry 10 times
   config.environments[:survey_gizmo_ruby][:max_attempts] = 10
@@ -77,10 +75,8 @@ Pester.configure do |config|
   # Retry different exception classes
   config.environments[:survey_gizmo_ruby][:retry_error_classes] = [MyExceptionClass, MyOtherExceptionClass]
 end
-```
 
-To set Pester to retry on ALL exception classes, do this (use with caution - this can include exceptions Rails likes to throw on SIGHUP)
-```ruby
+# To set Pester to retry on ALL exception classes, do this (use with caution! Can include exceptions Rails likes to throw on SIGHUP)
 Pester.configure do |config|
   config.environments[:survey_gizmo_ruby][:retry_error_classes] = nil
 end

--- a/README.md
+++ b/README.md
@@ -61,10 +61,14 @@ end
 
 ### Retries
 
-[Pester](https://github.com/lumoslabs/pester) will be configured to handle 1 retry with a 60 second timeout upon encountering basic net timeouts and rate limit errors.  If you want to specify more retries, a longer backoff, new classes to retry on, or otherwise get fancy with the retry strategy, you can configured Pester directly.  SurveyGizmo API calls are executed in Pester's `survey_gizmo_ruby` environment, so anything you configure there will apply to all your requests. **Just take care that you add additional `Pester` configuration AFTER you configure this gem** (configuring this gem will reset the `:survey_gizmo_ruby` Pester environment).
+The [Pester](https://github.com/lumoslabs/pester) gem is used to manage retry strategies.  By default it will be configured to handle 1 retry with a 60 second timeout upon encountering basic net timeouts and rate limit errors, which is enough for most people's needs.
+
+If, however, you want to specify more retries, a longer backoff, new classes to retry on, or otherwise get fancy with the retry strategy, you can configured Pester directly.  SurveyGizmo API calls are executed in Pester's `survey_gizmo_ruby` environment, so anything you configure there will apply to all your requests.
+
+**Just take care that you add additional `Pester` configuration AFTER you configure this gem** (configuring this gem will reset the `:survey_gizmo_ruby` Pester environment).
 
 For example, to change the retry interval, max attempts, or exception classes to be retried:
-```ruby```
+```ruby
 Pester.configure do |config|
   # Retry 10 times
   config.environments[:survey_gizmo_ruby][:max_attempts] = 10
@@ -73,7 +77,9 @@ Pester.configure do |config|
   # Retry different exception classes
   config.environments[:survey_gizmo_ruby][:retry_error_classes] = [MyExceptionClass, MyOtherExceptionClass]
 end
+```
 
+```ruby
 # To set Pester to retry on ALL exception classes, do this (use with caution - this can include exceptions Rails likes to throw on SIGHUP)
 ```ruby
 Pester.configure do |config|

--- a/lib/survey_gizmo/configuration.rb
+++ b/lib/survey_gizmo/configuration.rb
@@ -15,17 +15,13 @@ module SurveyGizmo
 
     Pester.configure do |c|
       c.environments[:survey_gizmo_ruby] = {
-        max_attempts: configuration.retries + 1,
-        delay_interval: configuration.retry_interval,
+        max_attempts: 2,
+        delay_interval: 60,
         on_retry: Pester::Behaviors::Sleep::Constant,
         logger: configuration.logger
       }
 
-      if configuration.retry_everything
-        c.environments[:survey_gizmo_ruby].delete(:retry_error_classes) rescue nil
-      else
-        c.environments[:survey_gizmo_ruby][:retry_error_classes] = retryables
-      end
+      c.environments[:survey_gizmo_ruby][:retry_error_classes] = retryables
     end
   end
 
@@ -47,17 +43,11 @@ module SurveyGizmo
     attr_accessor :api_version
     attr_accessor :logger
     attr_accessor :results_per_page
-    attr_accessor :retries
-    attr_accessor :retry_interval
-    attr_accessor :retry_everything
 
     def initialize
       @api_url = DEFAULT_REST_API_URL
       @api_version = DEFAULT_API_VERSION
       @results_per_page = DEFAULT_RESULTS_PER_PAGE
-      @retries = 1
-      @retry_interval = 60
-      @retry_everything = false
       @logger = ::Logger.new(STDOUT)
       @api_debug = ENV['GIZMO_DEBUG'].to_s =~ /^(true|t|yes|y|1)$/i
     end

--- a/lib/survey_gizmo/configuration.rb
+++ b/lib/survey_gizmo/configuration.rb
@@ -24,12 +24,12 @@ module SurveyGizmo
     def configure_pester
       Pester.configure do |c|
         c.environments[:survey_gizmo_ruby] = {
-          max_attempts: 2,
-          delay_interval: 60,
           on_retry: Pester::Behaviors::Sleep::Constant,
-          logger: configuration.logger,
-          retry_error_classes: retryables
+          logger: configuration.logger
         }
+        c.environments[:survey_gizmo_ruby][:max_attempts] ||= 2
+        c.environments[:survey_gizmo_ruby][:delay_interval] ||= 60
+        c.environments[:survey_gizmo_ruby][:retry_error_classes] ||= retryables
       end
     end
 

--- a/lib/survey_gizmo/configuration.rb
+++ b/lib/survey_gizmo/configuration.rb
@@ -35,8 +35,7 @@ module SurveyGizmo
         if c.environments[:survey_gizmo_ruby].nil?
           c.environments[:survey_gizmo_ruby] = default_config
         else
-          c.environments[:survey_gizmo_ruby][:max_attempts] ||= default_config[:max_attempts]
-          c.environments[:survey_gizmo_ruby][:delay_interval] ||= default_config[:delay_interval]
+          default_config.each { |k,v| c.environments[:survey_gizmo_ruby][k] ||= v unless k == :retry_error_classes }
 
           # Don't set :retry_error_classes to something when user has configured nothing
           if c.environments[:survey_gizmo_ruby][:retry_error_classes].nil? && !c.environments[:survey_gizmo_ruby].has_key?(:retry_error_classes)

--- a/lib/survey_gizmo/connection.rb
+++ b/lib/survey_gizmo/connection.rb
@@ -14,8 +14,6 @@ module SurveyGizmo
       private
 
       def connection
-        fail 'Not configured' unless SurveyGizmo.configuration
-
         options = {
           url: SurveyGizmo.configuration.api_url,
           params: { 'user:md5' => "#{SurveyGizmo.configuration.user}:#{Digest::MD5.hexdigest(SurveyGizmo.configuration.password)}" },

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '5.0.1'
+  VERSION = '5.0.2'
 end


### PR DESCRIPTION
@jarthod 2 minor things:
1. standard "not configured" exceptions are thrown when you attempt to use the gem before configuring it
2. i got rid of the pester configuration stuff from within the SG config block; people can just configure pester itself if they want to get fancy (put a clear explanation in the readme)