### PR TITLE
The API returns dates in GMT -4, not in EST.

### DIFF
--- a/lib/survey_gizmo/api/response.rb
+++ b/lib/survey_gizmo/api/response.rb
@@ -10,7 +10,7 @@ module SurveyGizmo::API
       {
         field: 'datesubmitted',
         operator: '>=',
-        value: time.in_time_zone('Eastern Time (US & Canada)').strftime('%Y-%m-%d %H:%M:%S')
+        value: time.in_time_zone(SurveyGizmo::Configuration::SURVEYGIZMO_TIME_ZONE).strftime('%Y-%m-%d %H:%M:%S')
       }
     end
 

--- a/lib/survey_gizmo/configuration.rb
+++ b/lib/survey_gizmo/configuration.rb
@@ -25,6 +25,7 @@ module SurveyGizmo
     DEFAULT_TIMEOUT_SECONDS = 300
     DEFAULT_RETRIES = 3
     DEFAULT_RETRY_INTERVAL = 60
+    SURVEYGIZMO_TIME_ZONE = 'Eastern Time (US & Canada)'
 
     attr_accessor :api_token
     attr_accessor :api_token_secret

--- a/lib/survey_gizmo/faraday_middleware/parse_survey_gizmo.rb
+++ b/lib/survey_gizmo/faraday_middleware/parse_survey_gizmo.rb
@@ -39,10 +39,10 @@ module SurveyGizmo
 
       # Handle really crappy [] notation in SG API, so far just in SurveyResponse
       Array.wrap(body['data']).compact.each do |datum|
-        # SurveyGizmo returns date information in EST but does not provide time zone information.
-        # See https://surveygizmov4.helpgizmo.com/help/article/link/date-and-time-submitted
+        # SurveyGizmo returns date information in GMT -4 but does not provide time zone information.
+        # See https://apihelp.surveygizmo.com/help/article/link/surveyresponse-returned-fields#examplereturns
         TIME_FIELDS.each do |time_key|
-          datum[time_key] = datum[time_key] + ' EST' unless datum[time_key].blank?
+          datum[time_key] = datum[time_key] + ' -0400' unless datum[time_key].blank?
         end
 
         datum.keys.grep(/^\[/).each do |key|

--- a/lib/survey_gizmo/faraday_middleware/parse_survey_gizmo.rb
+++ b/lib/survey_gizmo/faraday_middleware/parse_survey_gizmo.rb
@@ -42,7 +42,7 @@ module SurveyGizmo
         # SurveyGizmo returns date information using US/Eastern timezone but does not provide time zone information.
         # See https://apihelp.surveygizmo.com/help/article/link/surveyresponse-returned-fields#examplereturns
         TIME_FIELDS.each do |time_key|
-          datum[time_key] = ActiveSupport::TimeZone.new('US/Eastern').parse(datum[time_key]) unless datum[time_key].blank?
+          datum[time_key] = ActiveSupport::TimeZone.new(SurveyGizmo::Configuration::SURVEYGIZMO_TIME_ZONE).parse(datum[time_key]) unless datum[time_key].blank?
         end
 
         datum.keys.grep(/^\[/).each do |key|

--- a/lib/survey_gizmo/faraday_middleware/parse_survey_gizmo.rb
+++ b/lib/survey_gizmo/faraday_middleware/parse_survey_gizmo.rb
@@ -39,10 +39,10 @@ module SurveyGizmo
 
       # Handle really crappy [] notation in SG API, so far just in SurveyResponse
       Array.wrap(body['data']).compact.each do |datum|
-        # SurveyGizmo returns date information in GMT -4 but does not provide time zone information.
+        # SurveyGizmo returns date information using US/Eastern timezone but does not provide time zone information.
         # See https://apihelp.surveygizmo.com/help/article/link/surveyresponse-returned-fields#examplereturns
         TIME_FIELDS.each do |time_key|
-          datum[time_key] = datum[time_key] + ' -0400' unless datum[time_key].blank?
+          datum[time_key] = ActiveSupport::TimeZone.new('US/Eastern').parse(datum[time_key]) unless datum[time_key].blank?
         end
 
         datum.keys.grep(/^\[/).each do |key|

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -235,6 +235,14 @@ describe 'Survey Gizmo Resource' do
     it_should_behave_like 'an API object'
     it_should_behave_like 'an object with errors'
 
+    context 'during EST' do
+      let(:create_attributes) { {:survey_id => 1234, :datesubmitted => "2015-01-15 05:46:30" } }
+      let(:create_attributes_to_compare) { create_attributes.merge(:datesubmitted => Time.parse("2015-01-15 05:46:30 -0500")) }
+
+      it_should_behave_like 'an API object'
+      it_should_behave_like 'an object with errors'
+    end
+
     context 'answers' do
       let(:survey_id) { 6 }
       let(:response_id) { 7 }

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -221,7 +221,7 @@ describe 'Survey Gizmo Resource' do
 
   describe SurveyGizmo::API::Response do
     let(:create_attributes) { {:survey_id => 1234, :datesubmitted => "2015-04-15 05:46:30" } }
-    let(:create_attributes_to_compare) { create_attributes.merge(:datesubmitted => Time.parse("2015-04-15 05:46:30 EST")) }
+    let(:create_attributes_to_compare) { create_attributes.merge(:datesubmitted => Time.parse("2015-04-15 05:46:30 -0400")) }
     let(:get_attributes)    { create_attributes.merge(:id => 1) }
     let(:get_attributes_to_compare)    { create_attributes_to_compare.merge(:id => 1) }
     let(:update_attributes) { {:survey_id => 1234, :title => 'Updated'} }


### PR DESCRIPTION
The API does not return date information in EST but in GMT -4.
I noticed it on March 17th, probably because of the [clock change](http://www.timeanddate.com/time/change/usa/new-york) (from GMT -4 to GMT -5) which happened on March 13th.

The Survey Gizmo documentation seems inconsistent since they say that they're returning results in EST [here](https://surveygizmov4.helpgizmo.com/help/article/link/date-and-time-submitted) but in GMT -4 [here](https://apihelp.surveygizmo.com/help/article/link/surveyresponse-returned-fields#examplereturns) (The first link actually talks about exports, but I checked and if I'm not wrong, exports are using GMT -4 too).