### PR TITLE
Handle empty array as a response in .first

### DIFF
--- a/lib/survey_gizmo/resource.rb
+++ b/lib/survey_gizmo/resource.rb
@@ -64,6 +64,7 @@ module SurveyGizmo
       def first(conditions = {})
         data = Connection.get(create_route(:get, conditions)).body['data']
         data = {} if data.empty?
+        data = data[0] if data.is_a?(Array) && data.present?
         new(conditions.merge(data))
       end
 

--- a/lib/survey_gizmo/resource.rb
+++ b/lib/survey_gizmo/resource.rb
@@ -62,7 +62,9 @@ module SurveyGizmo
 
       # Retrieve a single resource.  See usage comment on .all
       def first(conditions = {})
-        new(conditions.merge(Connection.get(create_route(:get, conditions)).body['data']))
+        data = Connection.get(create_route(:get, conditions)).body['data']
+        data = {} if data.empty?
+        new(conditions.merge(data))
       end
 
       # Create a new resource object locally and save to SurveyGizmo.  Returns the newly created Resource instance.


### PR DESCRIPTION
I ran into this issue when querying the API for a Contact that did not exist using .first. The data in the body was returning an empty array rather than a hash in this case.