### PR TITLE
Fix escaping to resolve duplicate option issue

### DIFF
--- a/lib/survey_gizmo/api/answer.rb
+++ b/lib/survey_gizmo/api/answer.rb
@@ -17,11 +17,11 @@ module SurveyGizmo::API
       self.attributes = attrs
 
       case key
-      when /\[question\((\d+)\),\s*option\((\d+|"\d+-other")\)\]/
+      when /\[question\((\d+)\),\s*option\((\d+|\\\"\d+-other\\\")\)\]/
         self.question_id, self.option_id = $1, $2
 
-        if option_id =~ /-other/
-          option_id.delete!('-other"')
+        if option_id =~ /\\\"(\d+)-other\\\"/
+          option_id = $1
           self.other_text = value
         end
       when /\[question\((\d+)\),\s*question_pipe\("(.*)"\)\]/

--- a/lib/survey_gizmo/api/response.rb
+++ b/lib/survey_gizmo/api/response.rb
@@ -42,7 +42,7 @@ module SurveyGizmo::API
         # Strip out "Other" answers that don't actually have the "other" text (they come back as two responses - one
         # for the "Other" option_id, and then a whole separate response for the text given as an "Other" response.
         if k =~ /\[question\((\d+)\),\s*option\((\d+)\)\]/
-          !answers.keys.any? { |key| key =~ /\[question\((#{$1})\),\s*option\("(#{$2})-other"\)\]/ }
+          !answers.keys.any? { |key| key =~ /\[question\((#{$1})\),\s*option\(\\\"(#{$2})-other\\\"\)\]/ }
         else
           true
         end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -249,7 +249,7 @@ describe 'Survey Gizmo Resource' do
       let(:timestamp) { '2015-01-02'.to_time(:utc) }
       let(:answers) do
         {
-          "[question(3), option(\"10021-other\")]" => "Some other text field answer",
+          "[question(3), option(\\\"10021-other\\\")]" => "Some other text field answer",
           "[question(3), option(10021)]" => "Other (required)",
           "[question(5)]" => "VERY important",
           "[question(6)]" => nil,


### PR DESCRIPTION
Survey Gizmo's API returns a key containing a literal `\"` for 'other'
options, so the regex to match this needs to be `\\\"` to properly escape
the escape character.