### PR TITLE
Fix manual pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * **BREAKING CHANGE**: Pester has been removed as the retry source in favor of `Retriable`.
 * FEATURE: `Configuration#region` will configure the region to use the corresponding api and time zone. (#74)
 * Bugfix: fix escaping to resolve duplicate option issue (#75)
+* Bugfix: fix manual pagination (#82)
 
 ## Major Changes in 5.x
 

--- a/lib/survey_gizmo/resource.rb
+++ b/lib/survey_gizmo/resource.rb
@@ -44,7 +44,7 @@ module SurveyGizmo
           response = nil
 
           while !response || (all_pages && response['page'] < response['total_pages'])
-            conditions[:page] = response ? response['page'] + 1 : 1
+            conditions[:page] = response ? response['page'] + 1 : conditions.fetch(:page, 1) 
             logger.debug("Fetching #{name} page #{conditions} - #{conditions[:page]}#{response ? "/#{response['total_pages']}" : ''}...")
             response = Connection.get(create_route(:create, conditions)).body
             collection = response['data'].map { |datum| datum.is_a?(Hash) ? new(conditions.merge(datum)) : datum }

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '6.2.4'
+  VERSION = '6.2.5'
 end


### PR DESCRIPTION
Explicit pagination wasn't working. 

irb(main):008:0> SurveyGizmo::API::Survey.all(page: 3).count
2016-07-29 12:56:36 DEBUG Fetching SurveyGizmo::API::Survey page {:page=>1, :resultsperpage=>50} - 1...

This should fix it.