### PR TITLE
Add a rescue for parser errors 

### DIFF
--- a/lib/survey_gizmo/connection.rb
+++ b/lib/survey_gizmo/connection.rb
@@ -58,6 +58,7 @@ module SurveyGizmo
             SurveyGizmo::RateLimitExceededError,
             Errno::ETIMEDOUT,
             Net::ReadTimeout,
+            Faraday::Error::ParsingError,
             Faraday::Error::TimeoutError
           ]
         }

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '6.2.5'
+  VERSION = '6.2.6'
 end


### PR DESCRIPTION
for those not infrequent times recently when SurveyGizmo has an nginx failure and barfs with web content instead of a parseable API response 
@jarthod 