### PR TITLE
Bump up the max time retriable will retry for to 1 hour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Versions
 
+## 6.2.13
+* max_elapsed_time of 1 hour for retriable
+
 ## 6.2.12
 * Bugfix: Don't allow option_ids of 0
 

--- a/lib/survey_gizmo/connection.rb
+++ b/lib/survey_gizmo/connection.rb
@@ -53,6 +53,7 @@ module SurveyGizmo
         {
           base_interval: SurveyGizmo.configuration.retry_interval,
           tries: SurveyGizmo.configuration.retry_attempts + 1,
+          max_elapsed_time: 3600,
           on: [
             Errno::ETIMEDOUT,
             Faraday::Error::ClientError,

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '6.2.12'
+  VERSION = '6.2.13'
 end


### PR DESCRIPTION
I had configured 30 retries but the timeout got me after 15 minutes.  Really the entire retriable option hash should be passable; this is just a stopgap measure because their server is flaky today