### PR TITLE
Allow the configuration of the full Retriable options hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Versions
 
+## 6.2.13
+* max_elapsed_time of 1 hour for retriable
+
 ## 6.2.12
 * Bugfix: Don't allow option_ids of 0
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ end
 ```
 
 Check the [Retriable](https://github.com/kamui/retriable) documentation for how to configure the `retriable_params` hash.
+The default is to retry 3 times, with 60 seconds before the first retry and a slow exponential backoff after that.
 
 `api_token` and `api_token_secret` can be read from environment variables, in which case you would set them like this:
 

--- a/lib/survey_gizmo/configuration.rb
+++ b/lib/survey_gizmo/configuration.rb
@@ -51,6 +51,8 @@ module SurveyGizmo
 
     DEFAULT_RETRIABLE_PARAMS = {
       base_interval: 60,
+      max_interval: 300,
+      rand_factor: 0,
       tries: 4,
       on: [
         Errno::ETIMEDOUT,

--- a/lib/survey_gizmo/connection.rb
+++ b/lib/survey_gizmo/connection.rb
@@ -53,6 +53,7 @@ module SurveyGizmo
         {
           base_interval: SurveyGizmo.configuration.retry_interval,
           tries: SurveyGizmo.configuration.retry_attempts + 1,
+          max_elapsed_time: 3600,
           on: [
             Errno::ETIMEDOUT,
             Faraday::Error::ClientError,

--- a/lib/survey_gizmo/logger.rb
+++ b/lib/survey_gizmo/logger.rb
@@ -17,7 +17,7 @@ module SurveyGizmo
         )
       end
 
-      "#{timestamp.strftime('%Y-%m-%d %H:%M:%S')} #{severity} #{message}\n"
+      "[#{timestamp.strftime('%Y-%m-%d %H:%M:%S')} #{severity} (#{Process.pid})] #{message}\n"
     end
   end
 end

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '6.2.12'
+  VERSION = '6.2.13'
 end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper'
 
-describe SurveyGizmo::Configuration do
+describe SurveyGizmo::Logger do
+  let(:progname)    { 'TEST' }
+  let(:severity)    { 'INFO' }
+  let(:time_string) { '2015-04-15 05:46:30' }
+
   before(:each) do
     SurveyGizmo.configure do |config|
       config.api_token = 'king_of_the&whirled$'
       config.api_token_secret = 'dream/word'
     end
-    @severity = 'INFO'
-    @time_string = '2015-04-15 05:46:30'
-    @progname = 'TEST'
   end
 
   after(:each) do
@@ -18,60 +19,60 @@ describe SurveyGizmo::Configuration do
   it 'should mask unencoded api token' do
     config = SurveyGizmo.configuration
     formatted_message = config.logger.format_message(
-      @severity,
-      @time_string.to_time,
-      @progname,
+      severity,
+      time_string.to_time,
+      progname,
       config.api_token
     )
     expect(
       formatted_message
-    ).to eq(
-      "#{@time_string} #{@severity} <SG_API_KEY>\n"
+    ).to match(
+      /\[#{time_string} #{severity} \(\d+\)\] <SG_API_KEY>/
     )
   end
 
   it 'should mask percent encoded api token' do
     config = SurveyGizmo.configuration
     formatted_message = config.logger.format_message(
-      @severity,
-      @time_string.to_time,
-      @progname,
+      severity,
+      time_string.to_time,
+      progname,
       CGI.escape(config.api_token)
     )
     expect(
       formatted_message
-    ).to eq(
-      "#{@time_string} #{@severity} <SG_API_KEY>\n"
+    ).to match(
+      /\[#{time_string} #{severity} \(\d+\)\] <SG_API_KEY>/
     )
   end
 
   it 'should mask unencoded api token secret' do
     config = SurveyGizmo.configuration
     formatted_message = config.logger.format_message(
-      @severity,
-      @time_string.to_time,
-      @progname,
+      severity,
+      time_string.to_time,
+      progname,
       config.api_token_secret
     )
     expect(
       formatted_message
-    ).to eq(
-      "#{@time_string} #{@severity} <SG_API_SECRET>\n"
+    ).to match(
+      /\[#{time_string} #{severity} \(\d+\)\] <SG_API_SECRET>/
     )
   end
 
   it 'should mask percent encoded api token secret' do
     config = SurveyGizmo.configuration
     formatted_message = config.logger.format_message(
-      @severity,
-      @time_string.to_time,
-      @progname,
+      severity,
+      time_string.to_time,
+      progname,
       CGI.escape(config.api_token_secret)
     )
     expect(
       formatted_message
-    ).to eq(
-      "#{@time_string} #{@severity} <SG_API_SECRET>\n"
+    ).to match(
+      /\[#{time_string} #{severity} \(\d+\)\] <SG_API_SECRET>/
     )
   end
 end


### PR DESCRIPTION
Before you could only access two of the many [Retriable options](https://github.com/kamui/retriable).  

This PR allows you to merge in any configuration hash you want for the built in retries.

I preserved the existing functionality to avoid a major version bump but @mkaydev looks like you are doing a lot of work on the gem so take note.