### PR TITLE
remove unnecessary usage of alias_method_chain

### DIFF
--- a/lib/survey_gizmo/multilingual_title.rb
+++ b/lib/survey_gizmo/multilingual_title.rb
@@ -5,11 +5,10 @@ module SurveyGizmo
 
     included do
       attribute :title, Hash
-      alias_method_chain :title=, :multilingual
     end
 
-    def title_with_multilingual=(val)
-      self.title_without_multilingual = val.is_a?(Hash) ? val['English'] : val
+    def title=(val)
+      super(val.is_a?(Hash) ? val['English'] : val)
     end
   end
 end


### PR DESCRIPTION
This PR removes the usage of `alias_method_chain` in `SurveyGizmo::MultilingualTitle`. `alias_method_chain` has been deprecated in Rails 5.

Fixes #95