### PR TITLE
Handling resources that do not return data node

### DIFF
--- a/lib/survey_gizmo/resource.rb
+++ b/lib/survey_gizmo/resource.rb
@@ -137,7 +137,7 @@ module SurveyGizmo
     # Returns itself if successfully saved, but with attributes (like id) added by SurveyGizmo
     def save
       method, path = id ? [:post, :update] : [:put, :create]
-      self.attributes = Connection.send(method, create_route(path), attributes_without_blanks).body['data']
+      self.attributes = Connection.send(method, create_route(path), attributes_without_blanks).body['data'].to_h
       self
     end
 


### PR DESCRIPTION
Not all resources return a data node (i.e. Contacts). 

I was trying to create contacts for a campaign and was getting a "Expected nil to respond to #to_hash" from Virtus' `/virtus-1.0.5/lib/virtus/attribute_set.rb#197`

The issue is that SurveyGizmo only returns `{"result_ok"=>true, "id"=>100112272}` for new Contacts.

So this pull request forces nil to hash so that virtus doesn't choke.