### PR TITLE
Make the gem config thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Versions
+## 7.0.0
+* Makes configuration thread safe. When a new thread is created, the last configuration set through `SurveyGizmo.configure` will be used.
 
 ## 6.7.0
 * Change timezone for EU servers to UTC (#103)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ gem 'survey-gizmo-ruby'
 ## Configuration
 
 The configuration is thread safe.
-When a new thread is created, the last configuration set through `SurveyGizmo.configure` will be used.
+When a new thread is created, the last configuration set through `SurveyGizmo.configure` or `SurveyGizmo.configuration=` will be used.
 When `SurveyGizmo.reset!` is called, only the current thread configuration will be reset.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ gem 'survey-gizmo-ruby'
 
 ## Configuration
 
+The configuration is thread safe.
+When a new thread is created, the last configuration set through `SurveyGizmo.configure` will be used.
+When `SurveyGizmo.reset!` is called, only the current thread configuration will be reset.
+
 ```ruby
 require 'survey-gizmo-ruby'
 

--- a/lib/survey_gizmo/configuration.rb
+++ b/lib/survey_gizmo/configuration.rb
@@ -1,33 +1,36 @@
 require 'survey_gizmo/faraday_middleware/parse_survey_gizmo'
 
 module SurveyGizmo
+
+  CONFIG_THREAD_VARIABLE_NAME = :survey_gizmo_configuration
+
   class << self
     attr_writer :configuration
 
     def configuration
-      fail 'Not configured!' unless @configuration
-      @configuration
+      fail 'Not configured!' unless Thread.current[CONFIG_THREAD_VARIABLE_NAME]
+      Thread.current[CONFIG_THREAD_VARIABLE_NAME]
     end
 
     def configure
       reset!
-      yield(@configuration) if block_given?
+      yield(configuration) if block_given?
 
-      if @configuration.retry_attempts
-        @configuration.logger.warn('Configuring retry_attempts is deprecated; pass a retriable_params hash instead.')
-        @configuration.retriable_params[:tries] = @configuration.retry_attempts + 1
+      if configuration.retry_attempts
+        configuration.logger.warn('Configuring retry_attempts is deprecated; pass a retriable_params hash instead.')
+        configuration.retriable_params[:tries] = configuration.retry_attempts + 1
       end
 
-      if @configuration.retry_interval
-        @configuration.logger.warn('Configuring retry_interval is deprecated; pass a retriable_params hash instead.')
-        @configuration.retriable_params[:base_interval] = @configuration.retry_interval
+      if configuration.retry_interval
+        configuration.logger.warn('Configuring retry_interval is deprecated; pass a retriable_params hash instead.')
+        configuration.retriable_params[:base_interval] = configuration.retry_interval
       end
 
-      @configuration.retriable_params = Configuration::DEFAULT_RETRIABLE_PARAMS.merge(@configuration.retriable_params)
+      configuration.retriable_params = Configuration::DEFAULT_RETRIABLE_PARAMS.merge(configuration.retriable_params)
     end
 
     def reset!
-      @configuration = Configuration.new
+      Thread.current[CONFIG_THREAD_VARIABLE_NAME] = Configuration.new
       Connection.reset!
     end
   end

--- a/lib/survey_gizmo/configuration.rb
+++ b/lib/survey_gizmo/configuration.rb
@@ -5,11 +5,9 @@ module SurveyGizmo
   CONFIG_THREAD_VARIABLE_NAME = :survey_gizmo_configuration
 
   class << self
-    attr_writer :configuration
-
     def configuration
-      fail 'Not configured!' unless Thread.current[CONFIG_THREAD_VARIABLE_NAME]
-      Thread.current[CONFIG_THREAD_VARIABLE_NAME]
+      fail 'Not configured!' unless Thread.current[CONFIG_THREAD_VARIABLE_NAME] || @global_config
+      Thread.current[CONFIG_THREAD_VARIABLE_NAME] ||= @global_config.dup
     end
 
     def configure
@@ -27,6 +25,8 @@ module SurveyGizmo
       end
 
       configuration.retriable_params = Configuration::DEFAULT_RETRIABLE_PARAMS.merge(configuration.retriable_params)
+
+      @global_config = configuration
     end
 
     def reset!

--- a/lib/survey_gizmo/configuration.rb
+++ b/lib/survey_gizmo/configuration.rb
@@ -10,6 +10,11 @@ module SurveyGizmo
       Thread.current[CONFIG_THREAD_VARIABLE_NAME] ||= @global_config.dup
     end
 
+    def configuration=(new_config)
+      @global_config = new_config.dup
+      Thread.current[CONFIG_THREAD_VARIABLE_NAME] = new_config
+    end
+
     def configure
       reset!
       yield(configuration) if block_given?

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '6.7.0'
+  VERSION = '7.0.0'
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -2,10 +2,14 @@ require 'spec_helper'
 require 'survey_gizmo/configuration'
 
 describe SurveyGizmo::Configuration do
+
+  let(:api_token) { 'token' }
+  let(:api_token_secret) { 'doken' }
+
   before(:each) do
     SurveyGizmo.configure do |config|
-      config.api_token = 'token'
-      config.api_token_secret = 'doken'
+      config.api_token = api_token
+      config.api_token_secret = api_token_secret
     end
   end
 
@@ -23,6 +27,61 @@ describe SurveyGizmo::Configuration do
     end
 
     expect(SurveyGizmo::Connection.send(:connection).params).to eq('api_token' => 'slimthug', 'api_token_secret' => 'fourfourz')
+  end
+
+  context 'thread safety' do
+    it 'is set from the last known configuration' do
+      expect(SurveyGizmo.configuration.api_token).to eq(api_token)
+
+      Thread.new do
+        expect(SurveyGizmo.configuration.api_token).to eq(api_token)
+      end
+    end
+
+    it 'is not affected by a change in another thread' do
+      expect(SurveyGizmo.configuration.api_token).to eq(api_token)
+
+      Thread.new do
+        SurveyGizmo.configure {|c| c.api_token = 'new_token'}
+        expect(SurveyGizmo.configuration.api_token).to eq('new_token')
+      end.join
+
+      expect(SurveyGizmo.configuration.api_token).to eq(api_token)
+    end
+
+    it 'is not affected by a reset in another thread' do
+      expect(SurveyGizmo.configuration.api_token).to eq(api_token)
+
+      Thread.new do
+        SurveyGizmo.reset!
+        expect(SurveyGizmo.configuration.api_token).to eq(nil)
+      end.join
+
+      expect(SurveyGizmo.configuration.api_token).to eq(api_token)
+    end
+
+    it 'updates the last known configuration' do
+      expect(SurveyGizmo.configuration.api_token).to eq(api_token)
+
+      Thread.new do
+        SurveyGizmo.configure {|c| c.api_token = 'new_token'}
+        expect(SurveyGizmo.configuration.api_token).to eq('new_token')
+      end.join
+      Thread.new do
+        expect(SurveyGizmo.configuration.api_token).to eq('new_token')
+      end.join
+    end
+
+    it "doesn't hold references to the same attributes" do
+      expect(SurveyGizmo.configuration.api_token).to eq('token')
+
+      Thread.new do
+        SurveyGizmo.configuration.api_token << '_updated'
+        expect(SurveyGizmo.configuration.api_token).to eq('token_updated')
+      end.join
+
+      expect(SurveyGizmo.configuration.api_token).to eq('token')
+    end
   end
 
   describe '#region=' do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -3,8 +3,8 @@ require 'survey_gizmo/configuration'
 
 describe SurveyGizmo::Configuration do
 
-  let(:api_token) { 'token' }
-  let(:api_token_secret) { 'doken' }
+  let(:api_token) { "token" }
+  let(:api_token_secret) { "doken" }
 
   before(:each) do
     SurveyGizmo.configure do |config|
@@ -17,20 +17,20 @@ describe SurveyGizmo::Configuration do
     SurveyGizmo.reset!
   end
 
-  it 'should allow changing user and pass' do
+  it "should allow changing user and pass" do
     # preload connection to verify that memoization is purged
     SurveyGizmo::Connection.send(:connection)
 
     SurveyGizmo.configure do |config|
-      config.api_token = 'slimthug'
-      config.api_token_secret = 'fourfourz'
+      config.api_token = "slimthug"
+      config.api_token_secret = "fourfourz"
     end
 
-    expect(SurveyGizmo::Connection.send(:connection).params).to eq('api_token' => 'slimthug', 'api_token_secret' => 'fourfourz')
+    expect(SurveyGizmo::Connection.send(:connection).params).to eq("api_token" => "slimthug", "api_token_secret" => "fourfourz")
   end
 
-  context 'thread safety' do
-    it 'is set from the last known configuration' do
+  context "thread safety" do
+    it "is set from the last known configuration" do
       expect(SurveyGizmo.configuration.api_token).to eq(api_token)
 
       Thread.new do
@@ -38,18 +38,18 @@ describe SurveyGizmo::Configuration do
       end
     end
 
-    it 'is not affected by a change in another thread' do
+    it "is not affected by a change in another thread" do
       expect(SurveyGizmo.configuration.api_token).to eq(api_token)
 
       Thread.new do
-        SurveyGizmo.configure {|c| c.api_token = 'new_token'}
-        expect(SurveyGizmo.configuration.api_token).to eq('new_token')
+        SurveyGizmo.configure {|c| c.api_token = "new_token"}
+        expect(SurveyGizmo.configuration.api_token).to eq("new_token")
       end.join
 
       expect(SurveyGizmo.configuration.api_token).to eq(api_token)
     end
 
-    it 'is not affected by a reset in another thread' do
+    it "is not affected by a reset in another thread" do
       expect(SurveyGizmo.configuration.api_token).to eq(api_token)
 
       Thread.new do
@@ -60,27 +60,16 @@ describe SurveyGizmo::Configuration do
       expect(SurveyGizmo.configuration.api_token).to eq(api_token)
     end
 
-    it 'updates the last known configuration' do
+    it "updates the last known configuration" do
       expect(SurveyGizmo.configuration.api_token).to eq(api_token)
 
       Thread.new do
-        SurveyGizmo.configure {|c| c.api_token = 'new_token'}
-        expect(SurveyGizmo.configuration.api_token).to eq('new_token')
+        SurveyGizmo.configure {|c| c.api_token = "new_token"}
+        expect(SurveyGizmo.configuration.api_token).to eq("new_token")
       end.join
       Thread.new do
-        expect(SurveyGizmo.configuration.api_token).to eq('new_token')
+        expect(SurveyGizmo.configuration.api_token).to eq("new_token")
       end.join
-    end
-
-    it "doesn't hold references to the same attributes" do
-      expect(SurveyGizmo.configuration.api_token).to eq('token')
-
-      Thread.new do
-        SurveyGizmo.configuration.api_token << '_updated'
-        expect(SurveyGizmo.configuration.api_token).to eq('token_updated')
-      end.join
-
-      expect(SurveyGizmo.configuration.api_token).to eq('token')
     end
 
     describe ".configuration=" do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -82,6 +82,36 @@ describe SurveyGizmo::Configuration do
 
       expect(SurveyGizmo.configuration.api_token).to eq('token')
     end
+
+    describe ".configuration=" do
+      let(:new_config) { SurveyGizmo::Configuration.new.tap { |c| c.api_token = "new_token" } }
+
+      it "sets the configuration" do
+        expect{
+          SurveyGizmo.configuration = new_config
+        }.to change {
+          SurveyGizmo.configuration.api_token
+        }.from(api_token).to("new_token")
+      end
+
+      it "does not affect other threads" do
+        expect {
+          Thread.new do
+            SurveyGizmo.configuration = new_config
+            expect(SurveyGizmo.configuration.api_token).to eq("new_token")
+          end.join
+        }.not_to change {
+          SurveyGizmo.configuration.api_token
+        }.from(api_token)
+      end
+
+      it "updates the last known configuration" do
+        SurveyGizmo.configuration = new_config
+        Thread.new do
+          expect(SurveyGizmo.configuration.api_token).to eq("new_token")
+        end.join
+      end
+    end
   end
 
   describe '#region=' do


### PR DESCRIPTION
This PR makes the gem config thread safe by storing the configuration into a thread variable.

It probably deserves a bump of the major version number according to [semver](https://semver.org/) because even though the API won't change it might break some integrations relying on the sharing of configuration between threads. We should also add a warning about this in the changelog.

Another way to do this would be to return a client with its own config which will subsequently be used to make the calls like:
```ruby
client = SurveyGizmo::API::Client.new do |config|
  config.api_token = 'token'
  config.api_token_secret = 'secret'
end
surveys = client.all_surveys
```
But it'd require a massive rewrite of the gem and changes on all the integrations so that's why I didn't go this way.