### PR TITLE
Fix faraday_middleware deprecation error

### DIFF
--- a/lib/survey_gizmo/configuration.rb
+++ b/lib/survey_gizmo/configuration.rb
@@ -65,7 +65,7 @@ module SurveyGizmo
       tries: 4,
       on: [
         Errno::ETIMEDOUT,
-        Faraday::Error::ClientError,
+        Faraday::ClientError,
         Net::ReadTimeout,
         SurveyGizmo::BadResponseError,
         SurveyGizmo::RateLimitExceededError


### PR DESCRIPTION
Turns into an exception at 1.0.0